### PR TITLE
Disable UPX for macOS builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,7 @@ jobs:
     - name: Build binary
       run: make
     - name: Compress binary
+      if: matrix.go-os != 'darwin'
       uses: svenstaro/upx-action@2.4.1
       with:
         file: oidc-token-ferry${{ matrix.binary-suffix }}


### PR DESCRIPTION
It apparently doesn't work anymore due to Apple's restrictions.